### PR TITLE
Fix $symbol and $dominant_symbol

### DIFF
--- a/webtreemap.js
+++ b/webtreemap.js
@@ -77,8 +77,8 @@ function makeDom(tree, level) {
     dom.className += (' webtreemap-aggregate');
   }
 
-  for(key in tree.data){
-    if(key != '$area'){
+  for (key in tree.data) {
+    if (!key.startsWith('$')) {
       dom.setAttribute('data-' + key, tree.data[key]);
     }
   }


### PR DESCRIPTION
When creating custom data attributes, have makeDom() ignore tree.data keys
that begin with $. Avoids creating an attribute with the illegal name
"data-$symbol".

Broken since commit a994ee8c:
"Add an ability to set custom data on the dom elements."