### PR TITLE
size the whole tree map 100% of the body

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,12 +102,13 @@ async function main() {
   let output = `<!doctype html>
 <title>${title}</title>
 <style>
-body {
+html, body {
+  height: 100%;
   font-family: sans-serif;
 }
 #treemap {
-  width: 800px;
-  height: 600px;
+  height: 100%;
+  width: 100%;
 }
 </style>
 <div id='treemap'></div>


### PR DESCRIPTION
When resizing the window, the user now has to reload because the sub-trees are
fixed sizes (in pixels), but at least it work.